### PR TITLE
Added ability to use Characteristic OutletInUse as a trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ TPLink HS100/HS110 WiFi Smart Plug plugin for [Homebridge](https://github.com/nf
 The name set in the Kasa App will be used as the name in Homebridge.
 ```json
 "platforms": [{
-    "platform": "Hs100"
+    "platform": "Hs100",
+    "threshold": "5"
 }],
 ```
+Threshold: This value refers to the current power consumption. Everything smaller than this value will set the Characteristic OutletInUse to false (e.g. useful for power supplies or devices in standby, that constantly drain a small amount of power) - Optional, Default: 0
 
 ## Credits
 Thanks to George Georgovassilis and Thomas Baust for reverse engineering the HS1XX protocol.


### PR DESCRIPTION
Hi all,

thanks so far for sharing this great plugin! I made some modifications that allow the characteristic OutletInUse to be used as a trigger in HomeKit (e.g. you can set a certain lightning mode if your washing machine has finished :)):

- Added a new configuration value "threshold". A power consumption lower than this value means the Outlet is not use. Especially helpful if a device constantly drains power in standby
- Every 10 seconds the plugin checks the current power consumption, compares it to the threshold value and updates the Characteristic OutletInUse accordingly

Best regards
doooh