### PR TITLE
Fix issues caused by null config

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ class Hs100Platform {
     this.log = log;
     this.config = config || {};
     this.api = api;
-    this.plugs = config['plugs'] || [];
+    this.plugs = this.config['plugs'] || [];
     this.accessories = new Map();
 
     this.client = new Hs100Api.Client();


### PR DESCRIPTION
A quick fix for issues #16 and #17. It appears that `this.config` and `this.plugs` are no longer used, but just in case, I merely changed the `this.plugs` assignment so it wouldn’t try to access the null `config` from malformed configuration files.